### PR TITLE
Refactor getUrl method to use Azure's getBlobUrl method

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -9,14 +9,14 @@ class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
 {
     /**
      * The Azure Blob Client
-     * 
+     *
      * @var BlobRestProxy
      */
     private $client;
 
     /**
      * The container name
-     * 
+     *
      * @var string
      */
     private $container;

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -8,11 +8,18 @@ use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
 {
     /**
-     * Base file URL.
-     *
+     * The Azure Blob Client
+     * 
+     * @var BlobRestProxy
+     */
+    private $client;
+
+    /**
+     * The container name
+     * 
      * @var string
      */
-    protected $baseFileUrl;
+    private $container;
 
     /**
      * Create a new AzureBlobStorageAdapter instance.
@@ -24,8 +31,9 @@ class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     public function __construct(BlobRestProxy $client, $container, $prefix = null)
     {
         parent::__construct($client, $container, $prefix);
-
-        $this->baseFileUrl = $client->getPsrPrimaryUri().$container;
+        $this->client = $client;
+        $this->container = $container;
+        $this->setPathPrefix($prefix);
     }
 
     /**
@@ -34,8 +42,8 @@ class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
      * @param  string  $path
      * @return string
      */
-    public function getUrl($path)
+    public function getUrl(string $path)
     {
-        return $this->baseFileUrl.'/'.$path;
+        return $this->client->getBlobUrl($this->container, $path);
     }
 }

--- a/tests/AzureBlobStorageAdapterTest.php
+++ b/tests/AzureBlobStorageAdapterTest.php
@@ -10,7 +10,7 @@ class AzureBlobStorageAdapterTest extends TestCase
     /** @test */
     public function it_correctly_generates_the_file_url()
     {
-        $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey='.base64_encode('azure_key'));
+        $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
 
         $adapter = new AzureBlobStorageAdapter($client, 'azure_container');
 
@@ -25,11 +25,11 @@ class AzureBlobStorageAdapterTest extends TestCase
         $this->assertEquals('https://my_azure_storage_name.blob.core.windows.net/MY_AZURE_STORAGE_CONTAINER/test.txt', $storage->url('test.txt'));
     }
 
-     /** @test */
-     public function it_supports_preceding_slash()
-     {
-         $storage = $this->app['filesystem'];
- 
-         $this->assertEquals('https://my_azure_storage_name.blob.core.windows.net/MY_AZURE_STORAGE_CONTAINER/test.txt', $storage->url('/test.txt'));
-     }
+    /** @test */
+    public function it_supports_preceding_slash()
+    {
+        $storage = $this->app['filesystem'];
+
+        $this->assertEquals('https://my_azure_storage_name.blob.core.windows.net/MY_AZURE_STORAGE_CONTAINER/test.txt', $storage->url('/test.txt'));
+    }
 }

--- a/tests/AzureBlobStorageAdapterTest.php
+++ b/tests/AzureBlobStorageAdapterTest.php
@@ -24,4 +24,12 @@ class AzureBlobStorageAdapterTest extends TestCase
 
         $this->assertEquals('https://my_azure_storage_name.blob.core.windows.net/MY_AZURE_STORAGE_CONTAINER/test.txt', $storage->url('test.txt'));
     }
+
+     /** @test */
+     public function it_supports_preceding_slash()
+     {
+         $storage = $this->app['filesystem'];
+ 
+         $this->assertEquals('https://my_azure_storage_name.blob.core.windows.net/MY_AZURE_STORAGE_CONTAINER/test.txt', $storage->url('/test.txt'));
+     }
 }


### PR DESCRIPTION
This simplifies the retrieval of a blob's URL. A preceding forward slash on a file would cause a poorly formatted URL to be generated, where the BlobRestProxy's underlying method already handles this eventuality.

Advanced apologies! This is my first pull request