### PR TITLE
Updated getUrl() with custom url option

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -22,17 +22,26 @@ class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     private $container;
 
     /**
+     * Custom url for getUrl()
+     *
+     * @var string
+     */
+    private $url;
+
+    /**
      * Create a new AzureBlobStorageAdapter instance.
      *
      * @param  \MicrosoftAzure\Storage\Blob\BlobRestProxy  $client
      * @param  string  $container
+     * @param  string|null  $url
      * @param  string|null  $prefix
      */
-    public function __construct(BlobRestProxy $client, $container, $prefix = null)
+    public function __construct(BlobRestProxy $client, $container, $url, $prefix = null)
     {
         parent::__construct($client, $container, $prefix);
         $this->client = $client;
         $this->container = $container;
+        $this->url = $url;
         $this->setPathPrefix($prefix);
     }
 
@@ -44,6 +53,9 @@ class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
      */
     public function getUrl(string $path)
     {
+        if($this->url) {
+            return rtrim($this->url, '/') . '/' . $this->container . '/' . ltrim($path, '/');
+        }
         return $this->client->getBlobUrl($this->container, $path);
     }
 }

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -36,7 +36,7 @@ class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
      * @param  string|null  $url
      * @param  string|null  $prefix
      */
-    public function __construct(BlobRestProxy $client, $container, $url, $prefix = null)
+    public function __construct(BlobRestProxy $client, $container, string $url = null, $prefix = null)
     {
         parent::__construct($client, $container, $prefix);
         $this->client = $client;

--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -26,7 +26,7 @@ class AzureStorageServiceProvider extends ServiceProvider
                 $config['key']
             );
             $client = BlobRestProxy::createBlobService($endpoint);
-            $adapter = new AzureBlobStorageAdapter($client, $config['container']);
+            $adapter = new AzureBlobStorageAdapter($client, $config['container'], $config['url'] ?? null);
             return new Filesystem($adapter);
         });
     }


### PR DESCRIPTION
getUrl() now checks if a custom url has been set in the config and returns this if one has been set, else returns the standard url.  This does not affect other methods such as store, put, delete etc...

Use case for azure is where a custom CDN url is being used.