### PR TITLE
Updated getUrl() to handle azure $root container

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Then add this to the `disks` section of `config/filesystems.php`:
             'name'      => env('AZURE_STORAGE_NAME'),
             'key'       => env('AZURE_STORAGE_KEY'),
             'container' => env('AZURE_STORAGE_CONTAINER'),
+            'url'       => env('AZURE_STORAGE_URL'),
         ],
 ```
 
-Finally, add the fields `AZURE_STORAGE_NAME`, `AZURE_STORAGE_KEY` and `AZURE_STORAGE_CONTAINER` to your `.env` file with the appropriate credentials. Then you can set the `azure` driver as either your default or cloud driver and use it to fetch and retrieve files as usual.
+Finally, add the fields `AZURE_STORAGE_NAME`, `AZURE_STORAGE_KEY`, `AZURE_STORAGE_CONTAINER` and `AZURE_STORAGE_URL` to your `.env` file with the appropriate credentials. The `AZURE_STORAGE_URL` field is optional, this allows you to set a custom URL to be returned from `Storage::url()`, if using the `$root` continer the URL will be returned without the container path. Then you can set the `azure` driver as either your default or cloud driver and use it to fetch and retrieve files as usual.
 
 # Support policy
 

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -62,7 +62,7 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     public function getUrl(string $path)
     {
         if ($this->url) {
-            return rtrim($this->url, '/') . '/' . $this->container . '/' . ltrim($path, '/');
+            return rtrim($this->url, '/') . '/' . ($this->container === '$root' ? '' : $this->container . '/') . ltrim($path, '/');
         }
         return $this->client->getBlobUrl($this->container, $path);
     }

--- a/tests/AzureBlobStorageAdapterTest.php
+++ b/tests/AzureBlobStorageAdapterTest.php
@@ -43,6 +43,15 @@ class AzureBlobStorageAdapterTest extends TestCase
     }
 
     /** @test */
+    public function it_supports_custom_url_with_root_container()
+    {
+        $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
+        $adapter = new AzureBlobStorageAdapter($client, '$root', 'https://example.com');
+
+        $this->assertEquals('https://example.com/test.txt', $adapter->getUrl('test.txt'));
+    }
+
+    /** @test */
     public function it_handles_invalid_custom_url()
     {
         $this->expectException('Matthewbdaly\LaravelAzureStorage\Exceptions\InvalidCustomUrl');


### PR DESCRIPTION
Hi, thanks for accepting previous PR.  

I have modified the getUrl() function again to handle '$root' container in azure, eg:
    url= https://example.com
    container= $root
    file= example.txt
    Storage::disk('azure')->url('example.txt')= https://example.com/example.txt

I also updated README to mention changes and created an assertion to test.

I signed up for Travis CI too and everything appears to be passing.  I hope you're happy with these changes?

Thanks,
John