### PR TITLE
feat: support custom prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Then add this to the `disks` section of `config/filesystems.php`:
             'key'       => env('AZURE_STORAGE_KEY'),
             'container' => env('AZURE_STORAGE_CONTAINER'),
             'url'       => env('AZURE_STORAGE_URL'),
+            'prefix'    => null,
         ],
 ```
 
-Finally, add the fields `AZURE_STORAGE_NAME`, `AZURE_STORAGE_KEY`, `AZURE_STORAGE_CONTAINER` and `AZURE_STORAGE_URL` to your `.env` file with the appropriate credentials. The `AZURE_STORAGE_URL` field is optional, this allows you to set a custom URL to be returned from `Storage::url()`, if using the `$root` continer the URL will be returned without the container path. Then you can set the `azure` driver as either your default or cloud driver and use it to fetch and retrieve files as usual.
+Finally, add the fields `AZURE_STORAGE_NAME`, `AZURE_STORAGE_KEY`, `AZURE_STORAGE_CONTAINER` and `AZURE_STORAGE_URL` to your `.env` file with the appropriate credentials. The `AZURE_STORAGE_URL` field is optional, this allows you to set a custom URL to be returned from `Storage::url()`, if using the `$root` container the URL will be returned without the container path. A `prefix` can be optionally used. If it's not set, the container root is used. Then you can set the `azure` driver as either your default or cloud driver and use it to fetch and retrieve files as usual.
 
 # Support policy
 

--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -26,7 +26,12 @@ final class AzureStorageServiceProvider extends ServiceProvider
                 $config['key']
             );
             $client = BlobRestProxy::createBlobService($endpoint);
-            $adapter = new AzureBlobStorageAdapter($client, $config['container'], $config['url'] ?? null);
+            $adapter = new AzureBlobStorageAdapter(
+                $client,
+                $config['container'],
+                $config['url'] ?? null,
+                $config['prefix'] ?? null
+            );
             return new Filesystem($adapter);
         });
     }

--- a/tests/AzureBlobStorageAdapterTest.php
+++ b/tests/AzureBlobStorageAdapterTest.php
@@ -58,4 +58,13 @@ class AzureBlobStorageAdapterTest extends TestCase
         $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
         $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'foo');
     }
+
+    /** @test */
+    public function it_handles_custom_prefix()
+    {
+        $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
+        $adapter = new AzureBlobStorageAdapter($client, 'azure_container', null, 'test_path');
+
+        $this->assertEquals('https://azure_account.blob.core.windows.net/azure_container/test_path/test.txt', $adapter->getUrl('test_path/test.txt'));
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,6 +27,7 @@ class TestCase extends BaseTestCase
             'name'      => 'MY_AZURE_STORAGE_NAME',
             'key'       => base64_encode('MY_AZURE_STORAGE_KEY'),
             'container' => 'MY_AZURE_STORAGE_CONTAINER',
+            'prefix' => null,
         ]);
     }
 }


### PR DESCRIPTION
Hey,

this PR passes the defined option `prefix` to the `AzureBlobStorageAdapter`.

I have updated the tests and README. Everything seems to pass on Travis CI as you can see it [here](https://travis-ci.org/hakan0xFF/laravel-azure-storage).

Thx, Hakan