### PR TITLE
Pass config array to Filesystem

### DIFF
--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -32,7 +32,7 @@ final class AzureStorageServiceProvider extends ServiceProvider
                 $config['url'] ?? null,
                 $config['prefix'] ?? null
             );
-            return new Filesystem($adapter);
+            return new Filesystem($adapter, $config);
         });
     }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -14,4 +14,15 @@ class ServiceProviderTest extends TestCase
         $this->assertEquals('azure', $storage->getDefaultDriver());
         $this->assertEquals('azure', $storage->getDefaultCloudDriver());
     }
+
+    /** @test */
+    public function it_sets_up_the_config_correctly()
+    {
+        $storage = $this->app['filesystem'];
+        $settings = $this->app['config']->get('filesystems.disks.azure');
+
+        foreach($settings as $key => $value){
+            $this->assertEquals($value, $storage->getConfig()->get($key));
+        }
+    }
 }


### PR DESCRIPTION
Hello,

This PR passes the azure's config array to `Filesystem` so that global options can be used. 

The list of available options can be found here: 
https://flysystem.thephpleague.com/v1/docs/usage/setup/#global-configuration

I also wrote a unit test that asserts that azure's config array and `Filesystem` configuration have the same key,value pairs