### PR TITLE
Add support for custom blob endpoint

### DIFF
--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -21,10 +21,13 @@ final class AzureStorageServiceProvider extends ServiceProvider
     {
         Storage::extend('azure', function ($app, $config) {
             $endpoint = sprintf(
-                'DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s',
+                'DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;',
                 $config['name'],
                 $config['key']
             );
+            if ($config['endpoint'] !== null) {
+                $endpoint .= sprintf("BlobEndpoint=%s;", $config['endpoint']);
+            }
             $client = BlobRestProxy::createBlobService($endpoint);
             $adapter = new AzureBlobStorageAdapter(
                 $client,

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -2,8 +2,7 @@
 
 namespace Tests;
 
-use Storage;
-use Mockery as m;
+use Illuminate\Support\Facades\Storage;
 
 class ServiceProviderTest extends TestCase
 {
@@ -21,8 +20,30 @@ class ServiceProviderTest extends TestCase
         $storage = $this->app['filesystem'];
         $settings = $this->app['config']->get('filesystems.disks.azure');
 
-        foreach($settings as $key => $value){
+        foreach ($settings as $key => $value) {
             $this->assertEquals($value, $storage->getConfig()->get($key));
         }
+    }
+
+    /** @test */
+    public function it_handles_custom_blob_endpoint()
+    {
+        $endpoint = 'http://custom';
+        $container = $this->app['config']->get('filesystems.disks.azure.container');
+        $this->app['config']->set('filesystems.disks.azure.endpoint', $endpoint);
+
+        $this->assertEquals("$endpoint/$container/a.txt", Storage::url('a.txt'));
+    }
+
+    /** @test */
+    public function custom_url_overrides_endpoint()
+    {
+        $endpoint = 'http://custom';
+        $customUrl = 'http://cdn.com';
+        $container = $this->app['config']->get('filesystems.disks.azure.container');
+        $this->app['config']->set('filesystems.disks.azure.endpoint', $endpoint);
+        $this->app['config']->set('filesystems.disks.azure.url', $customUrl);
+
+        $this->assertEquals("$customUrl/$container/a.txt", Storage::url('a.txt'));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,7 @@ class TestCase extends BaseTestCase
             'driver'    => 'azure',
             'name'      => 'MY_AZURE_STORAGE_NAME',
             'key'       => base64_encode('MY_AZURE_STORAGE_KEY'),
+            'endpoint'  => null,
             'container' => 'MY_AZURE_STORAGE_CONTAINER',
             'prefix' => null,
         ]);


### PR DESCRIPTION
Resolves #17 

I don't know how great these tests are. Ideally the BlobRestProxy should be spied to see what the connection string looks like. Happy to take a stab at adding that if you like?