### PR TITLE
Added support for temporary url

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -2,9 +2,12 @@
 
 namespace Matthewbdaly\LaravelAzureStorage;
 
+use Illuminate\Support\Arr;
 use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter as BaseAzureBlobStorageAdapter;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use Matthewbdaly\LaravelAzureStorage\Exceptions\InvalidCustomUrl;
+use MicrosoftAzure\Storage\Blob\BlobSharedAccessSignatureHelper;
+use MicrosoftAzure\Storage\Common\Internal\Resources;
 
 /**
  * Blob storage adapter
@@ -33,15 +36,23 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     private $url;
 
     /**
+     * The account key to access the storage
+     *
+     * @var string
+     */
+    private $key;
+
+    /**
      * Create a new AzureBlobStorageAdapter instance.
      *
-     * @param  \MicrosoftAzure\Storage\Blob\BlobRestProxy $client    Client.
-     * @param  string                                     $container Container.
-     * @param  string|null                                $url       URL.
-     * @param  string|null                                $prefix    Prefix.
-     * @throws InvalidCustomUrl                                      URL is not valid.
+     * @param \MicrosoftAzure\Storage\Blob\BlobRestProxy $client Client.
+     * @param string $container Container.
+     * @param string $key
+     * @param string|null $url URL.
+     * @param string|null $prefix Prefix.
+     * @throws InvalidCustomUrl URL is not valid.
      */
-    public function __construct(BlobRestProxy $client, string $container, string $url = null, $prefix = null)
+    public function __construct(BlobRestProxy $client, string $container, string $key, string $url = null, $prefix = null)
     {
         parent::__construct($client, $container, $prefix);
         $this->client = $client;
@@ -50,6 +61,7 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
             throw new InvalidCustomUrl();
         }
         $this->url = $url;
+        $this->key = $key;
         $this->setPathPrefix($prefix);
     }
 
@@ -65,5 +77,35 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
             return rtrim($this->url, '/') . '/' . ($this->container === '$root' ? '' : $this->container . '/') . ltrim($path, '/');
         }
         return $this->client->getBlobUrl($this->container, $path);
+    }
+
+    /**
+     * Generate Temporary Url with SAS query
+     *
+     * @param string $path
+     * @param \Datetime|string $ttl
+     * @param array $options
+     * @return string
+     */
+    public function getTemporaryUrl(string $path, $ttl, array $options = [])
+    {
+        $sas = new BlobSharedAccessSignatureHelper($this->client->getAccountName(), $this->key);
+        $sasString = $sas->generateBlobServiceSharedAccessSignatureToken(
+            Resources::RESOURCE_TYPE_BLOB,
+            $this->container . '/' . $path,
+            Arr::get($options, 'signed_permissions', 'r'),
+            $ttl,
+            Arr::get($options, 'signed_start', ''),
+            Arr::get($options, 'signed_ip', ''),
+            Arr::get($options, 'signed_protocol', 'https'),
+            Arr::get($options, 'signed_identifier', ''),
+            Arr::get($options, 'cache_control', ''),
+            Arr::get($options, 'content_disposition', ''),
+            Arr::get($options, 'content_encoding', ''),
+            Arr::get($options, 'content_language', ''),
+            Arr::get($options, 'content_type', '')
+        );
+
+        return sprintf('%s?%s', $this->getUrl($path), $sasString);
     }
 }

--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -32,6 +32,7 @@ final class AzureStorageServiceProvider extends ServiceProvider
             $adapter = new AzureBlobStorageAdapter(
                 $client,
                 $config['container'],
+                $config['key'],
                 $config['url'] ?? null,
                 $config['prefix'] ?? null
             );


### PR DESCRIPTION
Hi!

I've added support for temporary URL's so you can use `Storage::temporaryUrl($file, now()->addMinutes(1))` to generate an URL which is only accessible for a given time period.

The only downside is that I had to make changes to the constructor of AzureBlobStorageAdapter which adds a new parameter (the account key) which is a breaking change if anyone would be using the AzureBlobStorageAdapter directly instead of using the Storage facade. The account key is required to sign a URL.

I'm open for feedback!

Kind regards