### PR TITLE
Resolve the Blob Client through the container

### DIFF
--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -20,15 +20,7 @@ final class AzureStorageServiceProvider extends ServiceProvider
     public function boot()
     {
         Storage::extend('azure', function ($app, $config) {
-            $endpoint = sprintf(
-                'DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;',
-                $config['name'],
-                $config['key']
-            );
-            if (isset($config['endpoint'])) {
-                $endpoint .= sprintf("BlobEndpoint=%s;", $config['endpoint']);
-            }
-            $client = BlobRestProxy::createBlobService($endpoint);
+            $client = $app->make(BlobRestProxy::class, $config);
             $adapter = new AzureBlobStorageAdapter(
                 $client,
                 $config['container'],
@@ -47,6 +39,17 @@ final class AzureStorageServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->app->bind(BlobRestProxy::class, function ($app, $config) {
+            $config = empty($config) ? $app->make('config')->get('filesystems.disks.azure') : $config;
+            $endpoint = sprintf(
+                'DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;',
+                $config['name'],
+                $config['key']
+            );
+            if (isset($config['endpoint'])) {
+                $endpoint .= sprintf("BlobEndpoint=%s;", $config['endpoint']);
+            }
+            return BlobRestProxy::createBlobService($endpoint);
+        });
     }
 }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Support\Facades\Storage;
+use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 
 final class ServiceProviderTest extends TestCase
 {
@@ -45,5 +46,15 @@ final class ServiceProviderTest extends TestCase
         $this->app['config']->set('filesystems.disks.azure.url', $customUrl);
 
         $this->assertEquals("$customUrl/$container/a.txt", Storage::url('a.txt'));
+    }
+
+    /** @test */
+    public function it_resolves_the_azure_client()
+    {
+        $this->assertTrue($this->app->bound(BlobRestProxy::class));
+
+        Storage::disk();
+
+        $this->assertTrue($this->app->resolved(BlobRestProxy::class));
     }
 }


### PR DESCRIPTION
Bind the `BlobRestProxy` to the container, so it can be resolved when the driver is created, but also when users need to access the client outside of the driver/adapter.

For example: `$client = app(BlobRestProxy::class)`

This resolves #25 in an elegant way for the following reasons:

- it prevents the abstraction leak from the adapter (which is marked as `final`)
- the service provider is the right place to register bindings in the container
- the `extend` callback shouldn't know _how_ to create the client, but rather get it from the service locator (container)

As @frankdejonge stated in https://github.com/thephpleague/flysystem-azure-blob-storage/issues/20, the `Flysystem` and the `AzureBlobStorageAdapter` does not need to be in the middle of the client and the application, but Laravel should provide access to it. 