### PR TITLE
Update AzureBlobStorageAdapter.php

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -91,10 +91,11 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
      */
     public function getTemporaryUrl(string $path, $ttl, array $options = [])
     {
+        $resourceName = (empty($path) ? $this->container : $this->container  . '/' . $path);
         $sas = new BlobSharedAccessSignatureHelper($this->client->getAccountName(), $this->key);
         $sasString = $sas->generateBlobServiceSharedAccessSignatureToken(
             Arr::get($options, 'signed_resource', 'b'),
-            $this->container . '/' . $path,
+            $resourceName,
             Arr::get($options, 'signed_permissions', 'r'),
             $ttl,
             Arr::get($options, 'signed_start', ''),

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -93,7 +93,7 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     {
         $sas = new BlobSharedAccessSignatureHelper($this->client->getAccountName(), $this->key);
         $sasString = $sas->generateBlobServiceSharedAccessSignatureToken(
-            Resources::RESOURCE_TYPE_BLOB,
+            Arr::get($options, 'signed_resource', 'b'),
             $this->container . '/' . $path,
             Arr::get($options, 'signed_permissions', 'r'),
             $ttl,


### PR DESCRIPTION
Allow the user to choose the resource within $options. generateBlobServiceSharedAccessSignatureToken() method currently support two type of resources:
- Resources::RESOURCE_TYPE_BLOB (b)
- Resources::RESOURCE_TYPE_CONTAINER (c)

The use case is generating SAS tokens for a mobile app so it can upload files to a container.