### PR TITLE
Added support for disk caching and retry middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ With SAS token authentication the endpoint is required. The value has the follow
 
 # Caching
 The package supports disk based caching as described in the [Laravel documentation](https://laravel.com/docs/filesystem#caching).
-To enable caching for the azure disk, add a cache directive to the disk's configuration options.
+To enable caching for the azure disk, add a `cache` directive to the disk's configuration options.
 ```php
         'azure' => [
             'driver'    => 'azure',
@@ -79,6 +79,21 @@ To enable caching for the azure disk, add a cache directive to the disk's config
                 'store' => 'memcached',
                 'expire' => 600,
                 'prefix' => 'filecache',
+            ]
+        ],
+```
+
+# Retries
+The Azure Storage SDK ships a [middleware to retry](https://github.com/Azure/azure-storage-php#retrying-failures) failed requests.
+To enable the retry middewalre, add a `retry` directive to the disk's configuration options.
+```php
+        'azure' => [
+            'driver'    => 'azure',
+            // Other Disk Options...
+            'retry'     => [
+                'tries' => 3,                   // number of retries
+                'interval' => 500,              // wait interval in ms
+                'increase' => 'exponential'     // how to increase the wait interval, options: linear, exponential
             ]
         ],
 ```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ With SAS token authentication the endpoint is required. The value has the follow
         ],
 ```
 
+# Caching
+The package supports disk based caching as described in the [Laravel documentation](https://laravel.com/docs/filesystem#caching).
+To enable caching for the azure disk, add a cache directive to the disk's configuration options.
+```php
+        'azure' => [
+            'driver'    => 'azure',
+            // Other Disk Options...
+            'cache'     => [
+                'store' => 'memcached',
+                'expire' => 600,
+                'prefix' => 'filecache',
+            ]
+        ],
+```
+
 # Support policy
 
 This package is supported on the current Laravel LTS version, and any later versions. If you are using an older Laravel version, it may work, but I offer no guarantees, nor will I accept pull requests to add this support.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ With SAS token authentication the endpoint is required. The value has the follow
 
 # Caching
 The package supports disk based caching as described in the [Laravel documentation](https://laravel.com/docs/filesystem#caching).
+This feature requires adding the package `league/flysystem-cached-adapter`:
+```bash
+composer require league/flysystem-cached-adapter:^1.1
+```
+
 To enable caching for the azure disk, add a `cache` directive to the disk's configuration options.
 ```php
         'azure' => [
@@ -91,9 +96,9 @@ To enable the retry middewalre, add a `retry` directive to the disk's configurat
             'driver'    => 'azure',
             // Other Disk Options...
             'retry'     => [
-                'tries' => 3,                   // number of retries
-                'interval' => 500,              // wait interval in ms
-                'increase' => 'exponential'     // how to increase the wait interval, options: linear, exponential
+                'tries' => 3,                   // number of retries, default: 3
+                'interval' => 500,              // wait interval in ms, default: 1000ms
+                'increase' => 'exponential'     // how to increase the wait interval, options: linear, exponential, default: linear
             ]
         ],
 ```

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "keywords": ["storage","laravel","azure"],
     "require": {
-        "league/flysystem-azure-blob-storage": "^0.1.6"
+        "league/flysystem-azure-blob-storage": "^0.1.6",
+        "league/flysystem-cached-adapter": "^1.1"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
     "type": "library",
     "keywords": ["storage","laravel","azure"],
     "require": {
-        "league/flysystem-azure-blob-storage": "^0.1.6",
-        "league/flysystem-cached-adapter": "^1.1"
+        "league/flysystem-azure-blob-storage": "^0.1.6"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",
@@ -14,7 +13,11 @@
         "php-coveralls/php-coveralls": "^2.1",
         "psy/psysh": "^0.9.9",
         "squizlabs/php_codesniffer": "^3.4",
-        "vimeo/psalm": "^3.16"
+        "vimeo/psalm": "^3.16",
+        "league/flysystem-cached-adapter": "^1.1"
+    },
+    "suggest": {
+        "league/flysystem-cached-adapter": "^1.1"
     },
     "license": "MIT",
     "authors": [

--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -13,6 +13,9 @@ use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddleware;
 use MicrosoftAzure\Storage\Common\Middlewares\RetryMiddlewareFactory;
 
+use RuntimeException;
+use Throwable;
+
 /**
  * Service provider for Azure Blob Storage
  */
@@ -37,6 +40,12 @@ final class AzureStorageServiceProvider extends ServiceProvider
 
             $cache = Arr::pull($config, 'cache');
             if ($cache) {
+                try {
+                    class_exists(CachedAdapter::class);
+                } catch (Throwable $e) {
+                    throw new RuntimeException("Caching requires the league/flysystem-cached-adapter to be installed.");
+                }
+
                 $adapter = new CachedAdapter($adapter, $this->createCacheStore($cache));
             }
 

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -22,8 +22,19 @@ final class ServiceProviderTest extends TestCase
         $settings = $this->app['config']->get('filesystems.disks.azure');
 
         foreach ($settings as $key => $value) {
+            if ($key === 'cache') {
+                continue;
+            }
+
             $this->assertEquals($value, $storage->getConfig()->get($key));
         }
+    }
+
+    /** @test */
+    public function it_sets_up_the_cache_adapter_correctly()
+    {
+        $adapter = Storage::getDriver()->getAdapter();
+        $this->assertEquals(\League\Flysystem\Cached\CachedAdapter::class, get_class($adapter));
     }
 
     /** @test */

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -68,4 +68,18 @@ final class ServiceProviderTest extends TestCase
 
         $this->assertTrue($this->app->resolved(BlobRestProxy::class));
     }
+
+    /** @test */
+    public function it_sets_up_the_retry_middleware()
+    {
+        $this->app['config']->set('filesystems.disks.azure.retry', [
+            'tries' => 3,
+            'interval' => 500,
+            'increase' => 'exponential'
+        ]);
+
+        $this->assertNotNull($this->app->get(BlobRestProxy::class));
+
+        $this->assertTrue($this->app->resolved(BlobRestProxy::class));
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,12 @@ abstract class TestCase extends BaseTestCase
             'key'       => base64_encode('MY_AZURE_STORAGE_KEY'),
             'endpoint'  => null,
             'container' => 'MY_AZURE_STORAGE_CONTAINER',
-            'prefix' => null,
+            'prefix'    => null,
+            'cache' => [
+                'store' => 'file',
+                'expire' => 60,
+                'prefix' => 'filecache',
+            ],
         ]);
     }
 }


### PR DESCRIPTION
I added support for the disk caching as described in the [Laravel documentation](https://laravel.com/docs/filesystem#caching).
The change is based on the frameworks [FilesystemManager](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Filesystem/FilesystemManager.php#L248), which provides the functionality for the shipped drivers.

Additionally I added support for the retry middleware as described in the [Azure Storage SDK](https://github.com/Azure/azure-storage-php#retrying-failures).