### PR TITLE
Supported root url

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -54,7 +54,7 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
      * @param string|null $prefix Prefix.
      * @throws InvalidCustomUrl URL is not valid.
      */
-    public function __construct(BlobRestProxy $client, string $container, string $key = null, string $url = null, $prefix = null)
+    public function __construct(BlobRestProxy $client, string $container, string $key = null, string $url = null, $prefix = null, $root_url = null)
     {
         parent::__construct($client, $container, $prefix);
         $this->client = $client;
@@ -64,6 +64,7 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
         }
         $this->url = $url;
         $this->key = $key;
+        $this->root_url = $root_url;
         $this->setPathPrefix($prefix);
     }
 
@@ -79,6 +80,13 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
         if ($this->url) {
             return rtrim($this->url, '/') . '/' . ($this->container === '$root' ? '' : $this->container . '/') . ltrim($path, '/');
         }
+
+        // allows the developer to
+        // have full control over the root path
+        if ($this->root_url) {
+            return rtrim($this->root_url, '/') . '/' . ltrim($path, '/');
+        }
+
         return $this->client->getBlobUrl($this->container, $path);
     }
 

--- a/src/AzureStorageServiceProvider.php
+++ b/src/AzureStorageServiceProvider.php
@@ -35,7 +35,8 @@ final class AzureStorageServiceProvider extends ServiceProvider
                 $config['container'],
                 $config['key'] ?? null,
                 $config['url'] ?? null,
-                $config['prefix'] ?? null
+                $config['prefix'] ?? null,
+                $config['root_url'] ?? null
             );
 
             if ($cache = Arr::pull($config, 'cache')) {

--- a/tests/AzureBlobStorageAdapterTest.php
+++ b/tests/AzureBlobStorageAdapterTest.php
@@ -78,4 +78,13 @@ final class AzureBlobStorageAdapterTest extends TestCase
 
         $this->assertEquals('https://azure_account.blob.core.windows.net/azure_container/test_path/test.txt', $adapter->getUrl('test_path/test.txt'));
     }
+
+    /** @test */
+    public function it_handles_custom_root_url()
+    {
+        $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
+        $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'azure_key',null, 'test_path', 'https://azure_account.blob.core.windows.net/azure_container/test_path');
+
+        $this->assertEquals('https://azure_account.blob.core.windows.net/azure_container/test_path/test.txt', $adapter->getUrl('test.txt'));
+    }
 }


### PR DESCRIPTION
This changes is to allow developers have the full control over the root url.
To solve the issue 
[https://github.com/matthewbdaly/laravel-azure-storage/issues/41](https://github.com/matthewbdaly/laravel-azure-storage/issues/41)