### PR TITLE
Update to support Laravel 9 with Flysystem V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Microsoft Azure Blob Storage integration for Laravel's Storage API.
 
-This is a custom driver for [Laravel's File Storage API](https://laravel.com/docs/8.x/filesystem), which is itself built on top of [Flysystem](https://flysystem.thephpleague.com/v1/docs/). It uses Flysystem's own Azure blob storage adapter, and so can't easily add any more functionality than that has - indeed, adding that would be out of scope for the project.
+This is a custom driver for [Laravel's File Storage API](https://laravel.com/docs/9.x/filesystem), which is itself built on top of [Flysystem 3](https://flysystem.thephpleague.com/docs/). It uses Flysystem's own Azure blob storage adapter, and so can't easily add any more functionality than that has - indeed, adding that would be out of scope for the project.
 
 # Installation
 
@@ -12,12 +12,6 @@ Install the package using composer:
 
 ```bash
 composer require matthewbdaly/laravel-azure-storage
-```
-
-On Laravel versions before 5.5 you also need to add the service provider to `config/app.php` manually:
-
-```php
-    Matthewbdaly\LaravelAzureStorage\AzureStorageServiceProvider::class,
 ```
 
 Then add this to the `disks` section of `config/filesystems.php`:
@@ -36,7 +30,7 @@ Then add this to the `disks` section of `config/filesystems.php`:
 
 Finally, add the fields `AZURE_STORAGE_NAME`, `AZURE_STORAGE_KEY`, `AZURE_STORAGE_CONTAINER` and `AZURE_STORAGE_URL` to your `.env` file with the appropriate credentials. The `AZURE_STORAGE_URL` field is optional, this allows you to set a custom URL to be returned from `Storage::url()`, if using the `$root` container the URL will be returned without the container path. A `prefix` can be optionally used. If it's not set, the container root is used. Then you can set the `azure` driver as either your default or cloud driver and use it to fetch and retrieve files as usual.
 
-For details on how to use this driver, refer to the [Laravel documentation on the file storage API](https://laravel.com/docs/filesystem).
+For details on how to use this driver, refer to the [Laravel documentation on the file storage API](https://laravel.com/docs/9.x/filesystem).
 
 # Custom endpoints
 
@@ -67,26 +61,6 @@ With SAS token authentication the endpoint is required. The value has the follow
             'url'       => env('AZURE_STORAGE_URL'),
             'prefix'    => null,
             'endpoint'  => env('AZURE_STORAGE_ENDPOINT'),
-        ],
-```
-
-# Caching
-The package supports disk based caching as described in the [Laravel documentation](https://laravel.com/docs/filesystem#caching).
-This feature requires adding the package `league/flysystem-cached-adapter`:
-```bash
-composer require league/flysystem-cached-adapter:^1.1
-```
-
-To enable caching for the azure disk, add a `cache` directive to the disk's configuration options.
-```php
-        'azure' => [
-            'driver'    => 'azure',
-            // Other Disk Options...
-            'cache'     => [
-                'store' => 'memcached',
-                'expire' => 600,
-                'prefix' => 'filecache',
-            ]
         ],
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -4,20 +4,16 @@
     "type": "library",
     "keywords": ["storage","laravel","azure"],
     "require": {
-        "league/flysystem-azure-blob-storage": "^1.0"
+        "league/flysystem-azure-blob-storage": "^3.0"
     },
     "require-dev": {
-        "league/flysystem-cached-adapter": "^1.1",
-        "mockery/mockery": "^1.0",
-        "orchestra/testbench": "^6.0",
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^7.0",
         "php-coveralls/php-coveralls": "^2.1",
         "phpunit/phpunit": "^9.3",
-        "psy/psysh": "^0.9.9",
+        "psy/psysh": "^0.11",
         "squizlabs/php_codesniffer": "^3.4",
         "vimeo/psalm": "^4.19"
-    },
-    "suggest": {
-        "league/flysystem-cached-adapter": "^1.1"
     },
     "license": "MIT",
     "authors": [

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -7,7 +7,6 @@ use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter as BaseAzureBlobSt
 use Matthewbdaly\LaravelAzureStorage\Exceptions\InvalidCustomUrl;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 use MicrosoftAzure\Storage\Blob\BlobSharedAccessSignatureHelper;
-use MicrosoftAzure\Storage\Common\Internal\Resources;
 
 /**
  * Blob storage adapter
@@ -51,11 +50,16 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
      * @param string $container Container.
      * @param string $key
      * @param string|null $url URL.
-     * @param string|null $prefix Prefix.
+     * @param string $prefix Prefix.
      * @throws InvalidCustomUrl URL is not valid.
      */
-    public function __construct(BlobRestProxy $client, string $container, string $key = null, string $url = null, $prefix = null)
-    {
+    public function __construct(
+        BlobRestProxy $client,
+        string $container,
+        string $key = null,
+        string $url = null,
+        $prefix = ''
+    ) {
         parent::__construct($client, $container, $prefix);
         $this->client = $client;
         $this->container = $container;
@@ -64,7 +68,6 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
         }
         $this->url = $url;
         $this->key = $key;
-        $this->setPathPrefix($prefix);
     }
 
     /**

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
 use MicrosoftAzure\Storage\Blob\BlobRestProxy;
 
@@ -19,23 +20,22 @@ final class ServiceProviderTest extends TestCase
     public function it_sets_up_the_config_correctly()
     {
         $storage = $this->app['filesystem'];
+
         $settings = $this->app['config']->get('filesystems.disks.azure');
 
         foreach ($settings as $key => $value) {
-            if ($key === 'cache') {
-                continue;
-            }
 
-            $this->assertEquals($value, $storage->getConfig()->get($key));
+            $this->assertEquals($value, Arr::get($storage->getConfig(), $key));
         }
     }
 
-    /** @test */
-    public function it_sets_up_the_cache_adapter_correctly()
-    {
-        $adapter = Storage::getDriver()->getAdapter();
-        $this->assertEquals(\League\Flysystem\Cached\CachedAdapter::class, get_class($adapter));
-    }
+//    /** @test */
+      // skip this test cause it's no longer valid
+//    public function it_sets_up_the_cache_adapter_correctly()
+//    {
+//        $adapter = Storage::getDriver()->getAdapter();
+//        $this->assertEquals(\League\Flysystem\Cached\CachedAdapter::class, get_class($adapter));
+//    }
 
     /** @test */
     public function it_handles_custom_blob_endpoint()


### PR DESCRIPTION
This add support to Laravel 9 With new Flysystem 3+

- but this is not backward compatible with Laravel 8.0 and before, i suggest this release as ^2.0 only
- Cache adaptor no longer exists in new version, so i removed it 
- test was updated on `it_sets_up_the_config_correctly` on changes how `Storage::getConfig` behave