### PR TITLE
(refactor/bugfix) remove prefix from getUrl method

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -47,20 +47,12 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     private $key;
 
     /**
-     * The prefix for the adapter
-     *
-     * @var string
-     */
-    private string $prefix;
-
-    /**
      * Create a new AzureBlobStorageAdapter instance.
      *
      * @param \MicrosoftAzure\Storage\Blob\BlobRestProxy $client Client.
      * @param string $container Container.
      * @param string $key
      * @param string|null $url URL.
-     * @param string $prefix Prefix.
      *
      * @throws InvalidCustomUrl URL is not valid.
      */
@@ -69,9 +61,8 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
         string $container,
         string $key = null,
         string $url = null,
-        string $prefix = ''
     ) {
-        parent::__construct($client, $container, $prefix);
+        parent::__construct($client, $container);
         $this->client = $client;
         $this->container = $container;
         if ($url && !filter_var($url, FILTER_VALIDATE_URL)) {
@@ -79,7 +70,6 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
         }
         $this->url = $url;
         $this->key = $key;
-        $this->prefix = $prefix;
     }
 
     /**
@@ -92,7 +82,7 @@ final class AzureBlobStorageAdapter extends BaseAzureBlobStorageAdapter
     public function getUrl(string $path)
     {
         if ($this->url) {
-            return rtrim($this->url, '/') . '/' . ($this->container === '$root' ? '' : $this->container . '/') . ($this->prefix ? $this->prefix . '/' : '') . ltrim($path, '/');
+            return rtrim($this->url, '/') . '/' . ($this->container === '$root' ? '' : $this->container . '/') . ltrim($path, '/');
         }
         return $this->client->getBlobUrl($this->container, $path);
     }

--- a/tests/Unit/AzureBlobStorageAdapterTest.php
+++ b/tests/Unit/AzureBlobStorageAdapterTest.php
@@ -58,9 +58,3 @@ it('handles custom prefix', function (): void {
     $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'azure_key', null, 'test_path');
     $this->assertEquals('https://azure_account.blob.core.windows.net/azure_container/test_path/test.txt', $adapter->getUrl('test_path/test.txt'));
 });
-
-it('includes the prefix in the return URL', function (): void {
-    $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
-    $adapter = new AzureBlobStorageAdapter($client, 'container', 'azure_key', 'https://example.com', 'my_prefix');
-    $this->assertEquals('https://example.com/container/my_prefix/test.txt', $adapter->getUrl('test.txt'));
-});

--- a/tests/Unit/AzureBlobStorageAdapterTest.php
+++ b/tests/Unit/AzureBlobStorageAdapterTest.php
@@ -40,7 +40,7 @@ it('supports custom URL with root container', function (): void {
 
 it('supports temporary URL', function (): void {
     $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
-    $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'azure_key', null, 'test_path');
+    $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'azure_key', null);
     $tempUrl = $adapter->getTemporaryUrl('test_path/test.txt', now()->addMinutes(1));
     $this->assertStringStartsWith('https://azure_account.blob.core.windows.net/azure_container/test_path/test.txt', $tempUrl);
     $this->assertStringContainsString('sig=', $tempUrl);
@@ -55,6 +55,6 @@ it('handles invalid custom URL', function (): void {
 
 it('handles custom prefix', function (): void {
     $client = BlobRestProxy::createBlobService('DefaultEndpointsProtocol=https;AccountName=azure_account;AccountKey=' . base64_encode('azure_key'));
-    $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'azure_key', null, 'test_path');
+    $adapter = new AzureBlobStorageAdapter($client, 'azure_container', 'azure_key', null);
     $this->assertEquals('https://azure_account.blob.core.windows.net/azure_container/test_path/test.txt', $adapter->getUrl('test_path/test.txt'));
 });

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -71,3 +71,17 @@ it('sets up the retry middleware', function (): void {
 
     $this->assertTrue($this->app->resolved(BlobRestProxy::class));
 });
+
+it('includes the prefix in the return URL', function (): void {
+    $endpoint = 'http://custom';
+    $customUrl = 'http://cdn.com';
+    $prefix = 'my_prefix';
+    assert($this->app['config'] instanceof Repository);
+    $container = $this->app['config']->get('filesystems.disks.azure.container');
+    assert(is_string($container));
+    $this->app['config']->set('filesystems.disks.azure.endpoint', $endpoint);
+    $this->app['config']->set('filesystems.disks.azure.url', $customUrl);
+    $this->app['config']->set('filesystems.disks.azure.prefix', $prefix);
+
+    $this->assertEquals("$customUrl/$container/$prefix/a.txt", Storage::url('a.txt'));
+});


### PR DESCRIPTION
Hi,

since the prefix is now appended to the URL in the Laravel framework, we no longer need to append the prefix ourselves in the getUrl method.

See [https://github.com/laravel/framework/commit/7cb6dbfae0420d388d9a2b5a7a068d2185ad308b](url)

Best regards